### PR TITLE
limit the concurrent chunk requests issued during statesync

### DIFF
--- a/core/types/block_fuzz_test.go
+++ b/core/types/block_fuzz_test.go
@@ -3,13 +3,13 @@ package types_test
 
 import (
 	"testing"
+
 	types "github.com/kwilteam/kwil-db/core/types"
 )
 
-
 func FuzzDecodeBlock(f *testing.F) {
 	// Seed corpus
-	testcases := []struct{
+	testcases := []struct {
 		rawBlk []byte
 	}{
 		{rawBlk: []byte{}},

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -705,7 +705,7 @@ func (bp *BlockProcessor) Commit(ctx context.Context, req *ktypes.CommitRequest)
 	}
 
 	// Snapshots:
-	if err := bp.snapshotDB(ctx, req.Height, req.Syncing); err != nil {
+	if err := bp.snapshotDB(ctx, req.Height); err != nil {
 		bp.log.Warn("Failed to create snapshot of the database", "err", err)
 	}
 
@@ -744,12 +744,12 @@ var (
 	statsyncExcludedTables   = []string{"kwild_internal.sentry"}
 )
 
-func (bp *BlockProcessor) snapshotDB(ctx context.Context, height int64, syncing bool) error {
+func (bp *BlockProcessor) snapshotDB(ctx context.Context, height int64) error {
 	snapshotsDue := bp.snapshotter.Enabled() &&
 		(bp.snapshotter.IsSnapshotDue(uint64(height)) || len(bp.snapshotter.ListSnapshots()) == 0)
 	// snapshotsDue = snapshotsDue && height > max(1, a.cfg.InitialHeight)
 
-	if snapshotsDue && !syncing {
+	if snapshotsDue {
 		// we make a snapshot tx but don't directly use it. This is because under the hood,
 		// we are using the pg_dump executable to create the snapshot, and we are simply
 		// giving pg_dump the snapshot ID to guarantee it has an isolated view of the database.


### PR DESCRIPTION
### Problem:
Currently, nodes joining the network via state sync are experiencing failures when downloading large snapshots (~2GB). This occurs because:
1. The current implementation launches concurrent fetchers for all the chunks, each requesting chunks of up to 16MB
2. Each chunk request has a hard 1-minute timeout which is more than reasonable for 
3. All chunk requests compete for network bandwidth, thereby leading to the request timeouts. (very evident with large chunk sizes)

The PR fixes this by reducing the number of concurrent chunk requests issued by the joining node to reduce the network load and giving enough bandwidth for these requests to succeed. 
