### PR TITLE
support ed25519 keys in the node and consensus engine

### DIFF
--- a/node/statesync_test.go
+++ b/node/statesync_test.go
@@ -50,7 +50,7 @@ var (
 )
 
 func newTestStatesyncer(ctx context.Context, t *testing.T, mn mock.Mocknet, rootDir string, sCfg *config.StateSyncConfig) (host.Host, discovery.Discovery, *snapshotStore, *StateSyncService, crypto.PrivateKey, error) {
-	priv, h := newTestHost(t, mn)
+	priv, h := newTestHost(t, mn, crypto.KeyTypeSecp256k1)
 	pkBts, _ := priv.Raw()
 	pk, err := crypto.UnmarshalSecp256k1PrivateKey(pkBts)
 	if err != nil {


### PR DESCRIPTION
`peerIDForValidator` by default assumes the keyType of the validators to be `secp256k1`, this PR fixes that to accept `ed25519` keys. Also adds consensus tests for both keys