### PR TITLE
add better test coverage for parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
-	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.34.0
 	go.opentelemetry.io/otel/metric v1.34.0
@@ -225,4 +224,12 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
+)
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYt
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -418,8 +418,8 @@ github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dz
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
-github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -617,6 +617,8 @@ github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -2212,18 +2212,27 @@ func Test_Actions(t *testing.T) {
 				return nil
 			})
 			if test.err != nil {
-				require.Error(t, err)
-				require.ErrorIs(t, err, test.err)
+				if err == nil {
+					require.Error(t, res.Error)
+					require.ErrorIs(t, res.Error, test.err)
+				} else {
+					require.Error(t, err)
+					require.ErrorIs(t, err, test.err)
+				}
 			} else if test.errContains != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), test.errContains)
+				if err == nil {
+					require.Error(t, res.Error)
+					require.Contains(t, res.Error.Error(), test.errContains)
+				} else {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), test.errContains)
+				}
 			} else {
 				require.NoError(t, err)
-			}
-
-			if test.executionErrContains != "" {
-				require.NotNil(t, res.Error)
-				require.Contains(t, res.Error.Error(), test.executionErrContains)
+				if test.executionErrContains != "" {
+					require.NotNil(t, res.Error)
+					require.Contains(t, res.Error.Error(), test.executionErrContains)
+				}
 			}
 
 			require.Equal(t, len(test.results), len(results))

--- a/node/engine/parse/antlr.go
+++ b/node/engine/parse/antlr.go
@@ -1198,16 +1198,18 @@ func (s *schemaVisitor) VisitCompound_operator(ctx *gen.Compound_operatorContext
 func (s *schemaVisitor) VisitOrdering_term(ctx *gen.Ordering_termContext) any {
 	ord := &OrderingTerm{
 		Expression: ctx.Sql_expr().Accept(s).(Expression),
-		Order:      OrderTypeAsc,
-		Nulls:      NullOrderLast,
 	}
 
 	if ctx.DESC() != nil {
 		ord.Order = OrderTypeDesc
+	} else if ctx.ASC() != nil {
+		ord.Order = OrderTypeAsc
 	}
 
 	if ctx.FIRST() != nil {
 		ord.Nulls = NullOrderFirst
+	} else if ctx.LAST() != nil {
+		ord.Nulls = NullOrderLast
 	}
 
 	ord.Set(ctx)
@@ -1327,8 +1329,9 @@ func (s *schemaVisitor) VisitJoin(ctx *gen.JoinContext) any {
 }
 
 func (s *schemaVisitor) VisitExpression_result_column(ctx *gen.Expression_result_columnContext) any {
+	expr := ctx.Sql_expr().Accept(s).(Expression)
 	col := &ResultColumnExpression{
-		Expression: ctx.Sql_expr().Accept(s).(Expression),
+		Expression: expr,
 	}
 
 	if ctx.Identifier() != nil {

--- a/node/engine/pg_generate/generate_test.go
+++ b/node/engine/pg_generate/generate_test.go
@@ -155,7 +155,7 @@ func Test_PgGenerate(t *testing.T) {
 		{
 			name: "window function",
 			sql:  "SELECT col1, col2, SUM(col3) OVER (PARTITION BY col1 ORDER BY col2) FROM tbl;",
-			want: "SELECT col1, col2, sum(col3) OVER (PARTITION BY col1 ORDER BY col2 ASC NULLS LAST) FROM tbl;",
+			want: "SELECT col1, col2, sum(col3) OVER (PARTITION BY col1 ORDER BY col2) FROM tbl;",
 		},
 		{
 			name: "array access",
@@ -345,7 +345,7 @@ func Test_PgGenerate(t *testing.T) {
 		{
 			name: "window function",
 			sql:  `SELECT col1, col2, row_number() OVER (PARTITION BY col1 ORDER BY col2) FROM tbl;`,
-			want: `SELECT col1, col2, row_number() OVER (PARTITION BY col1 ORDER BY col2 ASC NULLS LAST) FROM tbl;`,
+			want: `SELECT col1, col2, row_number() OVER (PARTITION BY col1 ORDER BY col2) FROM tbl;`,
 		},
 	}
 


### PR DESCRIPTION
This PR adds better test coverage for the parser and engine. It also finds a very minor bug in the parser, where it would incorrectly parse out default ordering. This issue isn't seen when using Kwil holistically because it is hidden by the default ordering, but if you use the `parse` package as a standalone package you would hit it.
