### PR TITLE
multi: Add new RPC method `chain.block_header`

### DIFF
--- a/core/rpc/json/chain/commands.go
+++ b/core/rpc/json/chain/commands.go
@@ -13,6 +13,12 @@ type BlockRequest struct {
 	Raw  bool       `json:"raw"`
 }
 
+type BlockHeaderRequest struct {
+	Height int64 `json:"height"`
+	// Hash is the block hash. If both Height and Hash are provided, hash will be used
+	Hash types.Hash `json:"hash"`
+}
+
 type BlockResultRequest struct {
 	Height int64 `json:"height"`
 	// Hash is the block hash. If both Height and Hash are provided, hash will be used

--- a/core/rpc/json/chain/methods.go
+++ b/core/rpc/json/chain/methods.go
@@ -8,6 +8,7 @@ const (
 	MethodVersion         jsonrpc.Method = "chain.version"
 	MethodHealth          jsonrpc.Method = "chain.health"
 	MethodBlock           jsonrpc.Method = "chain.block"
+	MethodBlockHeader     jsonrpc.Method = "chain.block_header"
 	MethodBlockResult     jsonrpc.Method = "chain.block_result"
 	MethodTx              jsonrpc.Method = "chain.tx"
 	MethodGenesis         jsonrpc.Method = "chain.genesis"

--- a/core/rpc/json/chain/responses.go
+++ b/core/rpc/json/chain/responses.go
@@ -23,6 +23,8 @@ type BlockResponse struct {
 
 type BlockResultResponse chaintypes.BlockResult
 
+type BlockHeaderResponse chaintypes.BlockHeader
+
 type TxResponse chaintypes.Tx
 
 // GenesisResponse is the same as kwil-db/config.GenesisConfig, with JSON tags.

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -14,6 +14,7 @@ type Tx struct {
 }
 
 type Block = types.Block
+type BlockHeader = types.BlockHeader
 type CommitInfo = types.CommitInfo
 
 type BlockResult struct {

--- a/go.mod
+++ b/go.mod
@@ -231,5 +231,4 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -617,8 +617,6 @@ github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/node/block.go
+++ b/node/block.go
@@ -613,6 +613,20 @@ func (n *Node) RawBlockByHash(hash types.Hash) ([]byte, *ktypes.CommitInfo, erro
 	return n.bki.GetRaw(hash)
 }
 
+// GetBlockHeader returns the block header by block hash.
+func (n *Node) GetBlockHeader(hash ktypes.Hash) (*ktypes.BlockHeader, error) {
+	return n.bki.GetBlockHeader(hash)
+}
+
+// GetBlockHeaderByHeight returns the block header by height. If height <= 0, the
+// latest block header will be returned.
+func (n *Node) GetBlockHeaderByHeight(height int64) (*ktypes.BlockHeader, error) {
+	if height <= 0 { // I think this is correct since block height starts from 1
+		height, _, _, _ = n.bki.Best()
+	}
+	return n.bki.GetBlockHeaderByHeight(height)
+}
+
 // BlockResultByHash returns the block result by block hash.
 func (n *Node) BlockResultByHash(hash types.Hash) ([]ktypes.TxResult, error) {
 	return n.bki.Results(hash)

--- a/node/services/jsonrpc/chainsvc/chain.openrpc.json
+++ b/node/services/jsonrpc/chainsvc/chain.openrpc.json
@@ -7,7 +7,7 @@
       "name": "CC0-1.0",
       "url": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
     },
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "methods": [
     {
@@ -46,6 +46,38 @@
           "$ref": "#/components/schemas/blockResponse"
         },
         "description": "block information at a certain height"
+      },
+      "paramStructure": "by-name"
+    },
+    {
+      "name": "chain.block_header",
+      "description": "retrieve certain block header info",
+      "params": [
+        {
+          "name": "hash",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "height",
+          "schema": {
+            "type": "integer"
+          },
+          "required": true
+        }
+      ],
+      "result": {
+        "name": "blockHeaderResponse",
+        "schema": {
+          "type": "object",
+          "$ref": "#/components/schemas/blockHeaderResponse"
+        },
+        "description": "block header information at a certain height"
       },
       "paramStructure": "by-name"
     },
@@ -232,6 +264,58 @@
         }
       },
       "blockHeader": {
+        "type": "object",
+        "properties": {
+          "Height": {
+            "type": "integer"
+          },
+          "MerkleRoot": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "NetworkParamsHash": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "NewLeader": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "NumTxns": {
+            "type": "integer"
+          },
+          "PrevAppHash": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "PrevHash": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "Timestamp": {
+            "type": "object",
+            "$ref": "#/components/schemas/time"
+          },
+          "ValidatorSetHash": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "Version": {
+            "type": "integer"
+          }
+        }
+      },
+      "blockHeaderResponse": {
         "type": "object",
         "properties": {
           "Height": {

--- a/node/services/jsonrpc/chainsvc/spec.go
+++ b/node/services/jsonrpc/chainsvc/spec.go
@@ -12,6 +12,6 @@ var (
 			Name: "CC0-1.0",
 			URL:  "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
 		},
-		Version: "0.1.0",
+		Version: apiSemver,
 	}
 )

--- a/node/store/memstore/memstore.go
+++ b/node/store/memstore/memstore.go
@@ -91,6 +91,30 @@ func (bs *MemBS) GetByHeight(height int64) (types.Hash, *types.Block, *types.Com
 	return blkHash.hash, blk, ci, nil
 }
 
+func (bs *MemBS) GetBlockHeader(hash types.Hash) (*types.BlockHeader, error) {
+	bs.mtx.RLock()
+	defer bs.mtx.RUnlock()
+	blk, have := bs.blocks[hash]
+	if !have {
+		return nil, types.ErrNotFound
+	}
+	return blk.Header, nil
+}
+
+func (bs *MemBS) GetBlockHeaderByHeight(height int64) (*types.BlockHeader, error) {
+	bs.mtx.RLock()
+	defer bs.mtx.RUnlock()
+	blkHash, have := bs.hashes[height]
+	if !have {
+		return nil, types.ErrNotFound
+	}
+	blk, have := bs.blocks[blkHash.hash]
+	if !have {
+		return nil, types.ErrNotFound
+	}
+	return blk.Header, nil
+}
+
 func (bs *MemBS) Have(blkid types.Hash) bool {
 	bs.mtx.RLock()
 	defer bs.mtx.RUnlock()

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -42,7 +42,9 @@ type BlockStore interface {
 type BlockGetter interface {
 	Have(Hash) bool
 	Get(Hash) (*types.Block, *types.CommitInfo, error)
-	GetByHeight(int64) (Hash, *types.Block, *types.CommitInfo, error) // note: we can impl GetBlockHeader easily too
+	GetByHeight(int64) (Hash, *types.Block, *types.CommitInfo, error)
+	GetBlockHeader(Hash) (*types.BlockHeader, error)
+	GetBlockHeaderByHeight(int64) (*types.BlockHeader, error)
 }
 
 type RawGetter interface {


### PR DESCRIPTION
## Description
This commit adds a new RPC method chain.block_header, which involved implementaion of new GetBlockHeaderByHeight and GetBlockHeader methods on *Node, *MemBS and *BlockStore.

Also, the stale rpc spec version was updated.

## Related Issue
Resolves #1506

## Motivation and Context
Feature request.

## How Has This Been Tested?
After configuring PostgreSQL, I started a test kwild daemon using `kwild start --autogen` and manually tested the new rpc method

```txt

~ kwil-db % curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"chain.block_header","params":{"height":100},"id":1}' http://0.0.0.0:8484/rpc/v1 | jq
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "Version": 0,
    "Height": 100,
    "NumTxns": 0,
    "PrevHash": "caefd257cbf82d59339d69e046ba45bdfd89edf12c23bf2c38e22c392f8df7e5",
    "PrevAppHash": "1e8453a02266c0e25409d6bc9f41ec2134c613aa6d036bc2a3a649c7d3f0e99b",
    "Timestamp": "2025-05-31T17:31:48.585Z",
    "MerkleRoot": "0000000000000000000000000000000000000000000000000000000000000000",
    "ValidatorSetHash": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
    "NetworkParamsHash": "d3e010a95bb2425e5e349c342e421d39f42c1e5af6c72befeac25a8067605451",
    "NewLeader": null
  }
}

```
Unit tests were also written to cover new methods.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (including inline docs)
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If a box does not apply, put `N/A`-->
<!--- For each box that has `N/A`, please explain why in the "Checklist Explanation" section. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (maybe?)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Checklist Explanation:
This is a new feature, and there's nowhere on the [Kwil Docs](https://docs.kwil.com) that requires an update; the RPC spec has been updated, so I think that's sufficient.

## How to Review this PR:
Look at the new methods introduced for code style check and correctness, then run the tests and spin a kwil daemon with `--autogen` flag to test the `chain.block_header` RPC method.

## Additional Information:
The new RPC method only returns the block header info, which is missing the block hash. If a block header is fetched with the height, the caller won't have the hash in the response unless they hit the `chain.block` method.

We can either add it to the `BlockHeaderResponse` or ignore.
 

