### PR TITLE
chore: export type map utility

### DIFF
--- a/node/pg/conn.go
+++ b/node/pg/conn.go
@@ -212,7 +212,7 @@ func NewPool(ctx context.Context, cfg *PoolConfig) (*Pool, error) {
 		return nil, err
 	}
 	defer writerConn.Release()
-	oidTypes := oidTypesMap(writerConn.Conn().TypeMap())
+	oidTypes := OidTypesMap(writerConn.Conn().TypeMap())
 
 	pool := &Pool{
 		readers:     db,

--- a/node/pg/db_live_test.go
+++ b/node/pg/db_live_test.go
@@ -616,7 +616,7 @@ func TestSelectLiteralType(t *testing.T) {
 
 	// Now with our high level func and mode.
 	args2 := append([]any{QueryModeInferredArgTypes}, args...)
-	results, err := query(ctx, oidTypesMap(conn.TypeMap()), &cqWrapper{conn}, stmt, args2...)
+	results, err := query(ctx, OidTypesMap(conn.TypeMap()), &cqWrapper{conn}, stmt, args2...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/pg/query.go
+++ b/node/pg/query.go
@@ -202,7 +202,7 @@ func query(ctx context.Context, oidToDataType map[uint32]*datatype, cq connQuery
 		if err != nil {
 			return nil, err
 		}
-		return decodeFromPG(pgxVals, oids, oidToDataType)
+		return DecodeFromPG(pgxVals, oids, oidToDataType)
 	})
 
 	ctag := rows.CommandTag()
@@ -311,7 +311,7 @@ func QueryRowFuncAny(ctx context.Context, tx sql.Executor, stmt string,
 
 func queryRowFuncAny(ctx context.Context, conn *pgx.Conn, stmt string,
 	fn func(vals []any) error, args ...any) error {
-	oidTypes := oidTypesMap(conn.TypeMap())
+	oidTypes := OidTypesMap(conn.TypeMap())
 
 	rows, _ := conn.Query(ctx, stmt, args...)
 	fields := rows.FieldDescriptions()

--- a/node/pg/types.go
+++ b/node/pg/types.go
@@ -809,11 +809,11 @@ func decodeFromPGVal(val any, oid uint32, oidToDataType map[uint32]*datatype) (a
 	return dt.Decode(val)
 }
 
-// decodeFromPG decodes several pgx types to their corresponding Go types.
+// DecodeFromPG decodes several pgx types to their corresponding Go types.
 // It is capable of detecting special Kwil types and decoding them to their
 // corresponding Go types. This is used when scanning blindly (into any or
 // using row.Values()) when pgx uses whatever pgtype types it prefers.
-func decodeFromPG(vals []any, oids []uint32, oidToDataType map[uint32]*datatype) ([]any, error) {
+func DecodeFromPG(vals []any, oids []uint32, oidToDataType map[uint32]*datatype) ([]any, error) {
 	var results []any
 	for i, oid := range oids {
 		if oid == voidOID {
@@ -831,9 +831,9 @@ func decodeFromPG(vals []any, oids []uint32, oidToDataType map[uint32]*datatype)
 	return results, nil
 }
 
-// oidTypesMap makes a map mapping oids to the Kwil type definition.
+// OidTypesMap makes a map mapping oids to the Kwil type definition.
 // It needs to be called after registerTypes.
-func oidTypesMap(conn *pgtype.Map) map[uint32]*datatype {
+func OidTypesMap(conn *pgtype.Map) map[uint32]*datatype {
 	m := make(map[uint32]*datatype)
 	for dt := range datatypes {
 		oid := dt.OID(conn)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Exporting `DecodeFromPG` and `OidTypesMap` is very helpful for fixing tx problems in https://github.com/trufnetwork/node/pull/1036. Otherwise it would be a burden to maintain synchronization between our typings.

This PR doesn't touch anything other than exporting those functions
