### PR TITLE
fix: race condition in consensus engine state info

### DIFF
--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -145,9 +145,7 @@ func (ce *ConsensusEngine) QueueTx(ctx context.Context, tx *types.Tx) error {
 	// and send a trigger to the CE if it's in the waiting state to start the new round.
 	if ce.role.Load() == types.RoleLeader {
 		ce.stateInfo.mtx.RLock()
-		status := ce.stateInfo.status
-
-		if status != Committed {
+		if ce.stateInfo.status != Committed {
 			// we do not defer r.Unlock because we dont want to hold a read
 			// lock through the cs.mempoolReadyChan <- struct{}{} call
 			ce.stateInfo.mtx.RUnlock()

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -145,15 +145,15 @@ func (ce *ConsensusEngine) QueueTx(ctx context.Context, tx *types.Tx) error {
 	// and send a trigger to the CE if it's in the waiting state to start the new round.
 	if ce.role.Load() == types.RoleLeader {
 		ce.stateInfo.mtx.RLock()
+		// we do not defer r.Unlock because we dont want to hold a read
+		// lock through the cs.mempoolReadyChan <- struct{}{} call
 		if ce.stateInfo.status != Committed {
-			// we do not defer r.Unlock because we dont want to hold a read
-			// lock through the cs.mempoolReadyChan <- struct{}{} call
-			ce.stateInfo.mtx.RUnlock()
+			ce.stateInfo.mtx.RUnlock() // unlock before returning
 			// send the mempoolReady trigger only during the
 			// newRound and waiting for blkProposal Timeout to elapse.
 			return nil
 		}
-		ce.stateInfo.mtx.RUnlock()
+		ce.stateInfo.mtx.RUnlock() // unlock before waiting on other goroutines
 
 		sz, _ := ce.mempool.Size()
 		if int64(sz) >= ce.ConsensusParams().MaxBlockSize {

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -308,10 +308,13 @@ func (ce *ConsensusEngine) commit(ctx context.Context, syncing bool) error {
 		ce.mempool.Remove(txHash)
 
 		txRes := ce.state.blockRes.txResults[idx]
+
+		ce.subMtx.Lock()
 		subChan, ok := ce.txSubscribers[txHash]
 		if ok { // Notify the subscribers about the transaction result
 			subChan <- txRes
 		}
+		ce.subMtx.Unlock()
 	}
 
 	mets.RecordCommit(ctx, time.Since(ce.state.tExecuted), height) // keep this before nextState()

--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -837,6 +837,8 @@ func (ce *ConsensusEngine) setLastCommitInfo(height int64, appHash []byte, blk *
 	ce.state.lc.blk = blk
 	ce.state.lc.commitInfo = ci
 
+	ce.stateInfo.mtx.Lock()
+	defer ce.stateInfo.mtx.Unlock()
 	ce.stateInfo.height = height
 	ce.stateInfo.status = Committed
 	ce.stateInfo.blkProp = nil


### PR DESCRIPTION
This PR fixes two race conditions in the consensus engine. The first race condition involves using potentially stale data in `QueueTx` if a block is concurrently being committed. The second race condition involves modifying state info without a lock.

EDIT:
I have since found another race condition in a similar line of code, and have added a fix. The race condition involved accessing a map in a concurrent goroutine without acquiring a lock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal locking mechanisms to enhance stability and prevent potential deadlocks during consensus operations. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->