### PR TITLE
fix: prevent AppHash divergence on PostgreSQL transaction abort

### DIFF
--- a/node/pg/repl.go
+++ b/node/pg/repl.go
@@ -311,12 +311,12 @@ func resetTransactionState(hasher *muhash.MuHash, stats *walStats, changesetWrit
 	stats.reset()
 	changesetWriter.finalize()
 	*seq = -1
-	
+
 	// TODO: Add telemetry for state reset events
 	// - Increment state_reset_total counter with reason (abort/rollback)
 	// - Record timestamp and validator ID
 	// - Track frequency to identify patterns
-	
+
 	logger.Debugf("Transaction state reset after abort/rollback")
 }
 
@@ -537,13 +537,13 @@ func decodeWALData(hasher *muhash.MuHash, walData []byte, relations map[uint32]*
 		logger.Warnf("Stream commit message: xid %d", logicalMsg.Xid)
 	case *pglogrepl.StreamAbortMessageV2:
 		logger.Warnf("Stream abort message: xid %d", logicalMsg.Xid)
-		
+
 		// TODO: Add telemetry/metrics for stream abort events
 		// - Increment stream_abort_total counter
 		// - Add WAL-free-space telemetry and fail early if below threshold
 		// - Check if abort was caused by disk space exhaustion
 		// - Consider surfacing hard error to Precommit for immediate block execution failure
-		
+
 		// Reset transaction state to prevent AppHash divergence
 		resetTransactionState(hasher, stats, changesetWriter, &seq)
 

--- a/node/pg/repl.go
+++ b/node/pg/repl.go
@@ -10,6 +10,13 @@ package pg
 // It recognizes UPDATEs to a special kwild_internal.sentry table, and captures
 // a sequence value to identify the committed transaction. If none was set, as
 // would be done by the DB type, it remains -1.
+//
+// TODO: Future enhancements for monitoring and telemetry:
+// - Add WAL-free-space telemetry and fail early if below threshold
+// - Add Prometheus metrics for abort/rollback events
+// - Consider surfacing hard errors to Precommit for immediate block execution failure
+// - Implement comprehensive health checks for PostgreSQL replication
+// See monitoring_backup/ directory for initial implementation that can be refined
 
 import (
 	"bytes"
@@ -297,6 +304,22 @@ func (ws *walStats) reset() {
 	*ws = walStats{}
 }
 
+// resetTransactionState cleans up all transaction-related state when a transaction
+// is aborted or rolled back, preventing AppHash divergence from dirty state.
+func resetTransactionState(hasher *muhash.MuHash, stats *walStats, changesetWriter *changesetIoWriter, seq *int64) {
+	hasher.Reset()
+	stats.reset()
+	changesetWriter.finalize()
+	*seq = -1
+	
+	// TODO: Add telemetry for state reset events
+	// - Increment state_reset_total counter with reason (abort/rollback)
+	// - Record timestamp and validator ID
+	// - Track frequency to identify patterns
+	
+	logger.Debugf("Transaction state reset after abort/rollback")
+}
+
 // decodeWALData decodes a wal data message given known relations, returning
 // true if it was a commit message, or a non-negative seq value if it was a
 // special update message on the internal sentry table
@@ -495,9 +518,13 @@ func decodeWALData(hasher *muhash.MuHash, walData []byte, relations map[uint32]*
 			logicalMsg.UserGID, logicalMsg.RollbackLSN, uint64(logicalMsg.RollbackLSN),
 			logicalMsg.EndLSN, uint64(logicalMsg.EndLSN))
 
-		// ROLLBACK PREPARED would happen after PREPARE transaction, which is
-		// where we finalized the changeset. The caller that aborted will simply
-		// discard the changeset hash that they already received.
+		// TODO: Add telemetry/metrics for rollback prepared events
+		// - Increment rollback_prepared_total counter
+		// - Record event with validator ID and timestamp
+		// - Consider surfacing hard error to Precommit for immediate block execution failure
+
+		// Reset transaction state to prevent AppHash divergence
+		resetTransactionState(hasher, stats, changesetWriter, &seq)
 
 	// v2 Stream control messages.  Only expected with large transactions.
 	case *pglogrepl.StreamStartMessageV2:
@@ -510,6 +537,15 @@ func decodeWALData(hasher *muhash.MuHash, walData []byte, relations map[uint32]*
 		logger.Warnf("Stream commit message: xid %d", logicalMsg.Xid)
 	case *pglogrepl.StreamAbortMessageV2:
 		logger.Warnf("Stream abort message: xid %d", logicalMsg.Xid)
+		
+		// TODO: Add telemetry/metrics for stream abort events
+		// - Increment stream_abort_total counter
+		// - Add WAL-free-space telemetry and fail early if below threshold
+		// - Check if abort was caused by disk space exhaustion
+		// - Consider surfacing hard error to Precommit for immediate block execution failure
+		
+		// Reset transaction state to prevent AppHash divergence
+		resetTransactionState(hasher, stats, changesetWriter, &seq)
 
 	default:
 		logger.Warnf("Unknown message type in pgoutput stream: %T", logicalMsg)

--- a/node/pg/repl_test.go
+++ b/node/pg/repl_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/trufnetwork/kwil-db/core/log"
 	"github.com/trufnetwork/kwil-db/core/utils/random"
+	"github.com/trufnetwork/kwil-db/node/utils/muhash"
 )
 
 // This not-a-unit-test isolates the unexported internal logical replication
@@ -140,4 +141,190 @@ func Test_repl(t *testing.T) {
 
 	wg.Wait() // to receive the commit id or an error
 	connQ.Close(ctx)
+}
+
+// TestResetTransactionState tests that resetTransactionState properly cleans up all state
+func TestResetTransactionState(t *testing.T) {
+	// Setup hasher with some data
+	hasher := muhash.New()
+	hasher.Add([]byte("test data"))
+	
+	// Setup stats with some counts
+	stats := &walStats{
+		inserts: 5,
+		updates: 3,
+		deletes: 2,
+		truncs:  1,
+	}
+	
+	// Setup changeset writer with mock channel
+	changesetChan := make(chan any, 10)
+	changesetWriter := &changesetIoWriter{
+		csChan: changesetChan,
+		metadata: &changesetMetadata{
+			relationIdx: map[[2]string]int{
+				{"test", "table"}: 0,
+			},
+			Relations: []*Relation{{Schema: "test", Table: "table"}},
+		},
+	}
+	
+	// Setup sequence with non-default value
+	seq := int64(42)
+	
+	// Verify initial state is dirty
+	if hasher.DigestHash() == [32]byte{} {
+		t.Error("hasher should have data before reset")
+	}
+	if stats.inserts == 0 && stats.updates == 0 && stats.deletes == 0 && stats.truncs == 0 {
+		t.Error("stats should have counts before reset")
+	}
+	if seq == -1 {
+		t.Error("seq should not be -1 before reset")
+	}
+	
+	// Call resetTransactionState
+	resetTransactionState(hasher, stats, changesetWriter, &seq)
+	
+	// Verify hasher is reset
+	emptyHash := muhash.New().DigestHash()
+	if hasher.DigestHash() != emptyHash {
+		t.Error("hasher should be reset to empty state")
+	}
+	
+	// Verify stats are reset
+	if stats.inserts != 0 || stats.updates != 0 || stats.deletes != 0 || stats.truncs != 0 {
+		t.Error("stats should be reset to zero")
+	}
+	
+	// Verify sequence is reset
+	if seq != -1 {
+		t.Errorf("seq should be reset to -1, got %d", seq)
+	}
+	
+	// Verify changeset writer finalize was called (channel should be closed)
+	select {
+	case _, ok := <-changesetChan:
+		if ok {
+			t.Error("changeset channel should be closed after finalize")
+		}
+	default:
+		t.Error("changeset channel should be closed after finalize")
+	}
+}
+
+// TestStreamAbortMessageV2StateReset tests that StreamAbortMessageV2 triggers proper state reset
+func TestStreamAbortMessageV2StateReset(t *testing.T) {
+	// Setup dirty state
+	hasher := muhash.New()
+	hasher.Add([]byte("dirty data"))
+	
+	stats := &walStats{inserts: 1, updates: 2}
+	seq := int64(100)
+	
+	changesetChan := make(chan any, 1)
+	changesetWriter := &changesetIoWriter{
+		csChan: changesetChan,
+		metadata: &changesetMetadata{
+			relationIdx: make(map[[2]string]int),
+		},
+	}
+	
+	// Test the reset function directly (simulating StreamAbortMessageV2 handling)
+	resetTransactionState(hasher, stats, changesetWriter, &seq)
+	
+	// Verify state was reset
+	emptyHash := muhash.New().DigestHash()
+	if hasher.DigestHash() != emptyHash {
+		t.Error("hasher should be reset after StreamAbortMessageV2")
+	}
+	if stats.inserts != 0 || stats.updates != 0 {
+		t.Error("stats should be reset after StreamAbortMessageV2")  
+	}
+	if seq != -1 {
+		t.Error("seq should be reset to -1 after StreamAbortMessageV2")
+	}
+}
+
+// TestRollbackPreparedMessageV3StateReset tests that RollbackPreparedMessageV3 triggers proper state reset
+func TestRollbackPreparedMessageV3StateReset(t *testing.T) {
+	// Setup dirty state
+	hasher := muhash.New()
+	hasher.Add([]byte("prepared transaction data"))
+	
+	stats := &walStats{
+		inserts: 10,
+		updates: 5,
+		deletes: 3,
+		truncs:  1,
+	}
+	
+	seq := int64(200)
+	
+	changesetChan := make(chan any, 1)
+	changesetWriter := &changesetIoWriter{
+		csChan: changesetChan,
+		metadata: &changesetMetadata{
+			relationIdx: make(map[[2]string]int),
+		},
+	}
+	
+	// Test the reset function directly (simulating RollbackPreparedMessageV3 handling)
+	resetTransactionState(hasher, stats, changesetWriter, &seq)
+	
+	// Verify state was reset
+	emptyHash := muhash.New().DigestHash()
+	if hasher.DigestHash() != emptyHash {
+		t.Error("hasher should be reset after RollbackPreparedMessageV3")
+	}
+	if stats.inserts != 0 || stats.updates != 0 || stats.deletes != 0 || stats.truncs != 0 {
+		t.Error("stats should be reset after RollbackPreparedMessageV3")
+	}
+	if seq != -1 {
+		t.Error("seq should be reset to -1 after RollbackPreparedMessageV3")
+	}
+}
+
+// TestAppHashConsistencyAfterAbort tests that AppHash remains consistent after transaction abort
+func TestAppHashConsistencyAfterAbort(t *testing.T) {
+	// Create two identical hashers
+	hasher1 := muhash.New()
+	hasher2 := muhash.New()
+	
+	// Both hashers process same initial data
+	testData := []byte("some transaction data")
+	hasher1.Add(testData)
+	hasher2.Add(testData)
+	
+	// Verify they have same hash
+	hash1 := hasher1.DigestHash()
+	hash2 := hasher2.DigestHash()
+	if hash1 != hash2 {
+		t.Error("initial hashes should be identical")
+	}
+	
+	// Simulate abort scenario: hasher1 gets aborted and reset, hasher2 continues
+	stats1 := &walStats{}
+	seq1 := int64(50)
+	changesetWriter1 := &changesetIoWriter{
+		metadata: &changesetMetadata{relationIdx: make(map[[2]string]int)},
+	}
+	
+	// hasher1 experiences abort and gets reset
+	resetTransactionState(hasher1, stats1, changesetWriter1, &seq1)
+	
+	// hasher2 continues without abort (simulating validator with sufficient disk space)
+	// Both now process the same next transaction
+	nextData := []byte("next successful transaction")
+	hasher1.Add(nextData)
+	hasher2.Reset() // hasher2 also resets because it commits successfully
+	hasher2.Add(nextData)
+	
+	// Final hashes should be identical
+	finalHash1 := hasher1.DigestHash()
+	finalHash2 := hasher2.DigestHash()
+	if finalHash1 != finalHash2 {
+		t.Errorf("final hashes should be identical after proper reset, got %x vs %x", 
+			finalHash1, finalHash2)
+	}
 }


### PR DESCRIPTION
Add resetTransactionState() to properly clean up transaction state when PostgreSQL emits StreamAbortMessageV2 or RollbackPreparedMessageV3 messages. This prevents MuHash from retaining dirty state that would cause validators to produce different AppHashes after WAL space exhaustion.

The fix ensures:
- MuHash hasher is reset to clean state
- WAL statistics are cleared
- Changeset writer is finalized
- Sequence number is reset to -1

Added TODO comments for future telemetry enhancements

resolves: https://github.com/trufnetwork/kwil-db/issues/1549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by ensuring transaction state is fully reset after aborts or rollbacks, preventing inconsistencies.  
* **Tests**
  * Added comprehensive tests to verify transaction state resets and app hash consistency after abort scenarios.  
* **Chores**
  * Added internal comments outlining future plans for telemetry and monitoring enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->