### PR TITLE
chore: auto-blacklist peers that exhaust connection retries

### DIFF
--- a/node/peers/peers.go
+++ b/node/peers/peers.go
@@ -328,6 +328,13 @@ func (pm *PeerMan) maintainMinPeers(ctx context.Context) {
 				if !bk.try() {
 					if bk.maxedOut() {
 						pm.log.Warnf("Failed to connect to peer %s (%v) after %d attempts", peerIDStringer(pid), pid, bk.attempts)
+
+						// Auto-blacklist peer that exhausted connection retries if enabled
+						if pm.blacklistConfig.Enable && pm.blacklistConfig.AutoBlacklistOnMaxRetries {
+							pm.log.Warnf("Auto-blacklisting peer %s due to connection exhaustion after %d attempts", peerIDStringer(pid), bk.attempts)
+							pm.BlacklistPeer(pid, "connection_exhaustion", 0) // permanent blacklist
+						}
+
 						pm.removePeer(pid)
 					}
 					continue


### PR DESCRIPTION
Automatically blacklist peers that exhaust connection attempts to prevent infinite retry cycles and resource waste from PEX rediscovery.

- Add auto-blacklist logic to maintainMinPeers() retry exhaustion handler
- Permanently blacklist peers with reason "connection_exhaustion" when maxedOut()
- Only activate when both blacklist.enable and auto_blacklist_on_max_retries are true
- Add comprehensive test coverage for all configuration scenarios
- Verify blacklisted peers are rejected by connection gating (prevents PEX re-addition)

resolves: https://github.com/trufnetwork/kwil-db/issues/1562