### PR TITLE
fix: Prevent negative balances in ERC20 bridge transfers

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -662,6 +662,25 @@ func init() {
 								return err
 							}
 
+							// Check sufficient balance before transfer
+							currentBalance, err := balanceOf(ctx.TxContext.Ctx, app, id, from)
+							if err != nil {
+								return err
+							}
+
+							// If user has no balance record, treat as zero balance
+							if currentBalance == nil {
+								return fmt.Errorf("insufficient balance: have 0, need %s", amount)
+							}
+
+							cmp, err := currentBalance.Cmp(amount)
+							if err != nil {
+								return err
+							}
+							if cmp < 0 {
+								return fmt.Errorf("insufficient balance: have %s, need %s", currentBalance, amount)
+							}
+
 							return transferTokens(ctx.TxContext.Ctx, app, id, from, toAddr, amount)
 						},
 					},


### PR DESCRIPTION
Adds balance validation to the ERC20 bridge transfer method to prevent users from transferring more tokens than they own, which previously resulted in negative account balances.

- Added `balanceOf()` check before executing transfers in meta extension
- Handles users with no balance records (treats as zero balance)
- Returns clear error messages: `"insufficient balance: have X, need Y"`

resolves: https://github.com/trufnetwork/kwil-db/issues/1608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents ERC20 bridge transfers from proceeding when the sender’s balance is insufficient by validating balance before transfer.
  * Provides clearer, consistent error messages that state the available and required amounts for failed transfers.
* **Stability**
  * Improves reliability of ERC20 transfers with stricter pre-transfer checks.
* **Compatibility**
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->