### PR TITLE
chore: add recipient param to bridge & fix blacklist

### DIFF
--- a/node/exts/erc20-bridge/erc20/for_test_epoch_shims.go
+++ b/node/exts/erc20-bridge/erc20/for_test_epoch_shims.go
@@ -197,5 +197,5 @@ func ForTestingLockAndIssueDirect(ctx context.Context, platform *kwilTesting.Pla
 		return fmt.Errorf("invalid address: %s", from)
 	}
 	addr := ethcommon.HexToAddress(from)
-	return lockAndIssue(ctx, app, id, epochID, addr, dec)
+	return lockAndIssue(ctx, app, id, epochID, addr, addr, dec)
 }

--- a/node/exts/erc20-bridge/erc20/named_extension.go
+++ b/node/exts/erc20-bridge/erc20/named_extension.go
@@ -177,6 +177,7 @@ func init() {
 				{
 					Name: "bridge",
 					Parameters: []precompiles.PrecompileValue{
+						{Name: "recipient", Type: types.TextType},
 						{Name: "amount", Type: uint256Numeric},
 					},
 					AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC},

--- a/node/p2p.go
+++ b/node/p2p.go
@@ -10,6 +10,7 @@ import (
 
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/discovery"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -73,7 +74,11 @@ func NewP2PService(ctx context.Context, cfg *P2PServiceConfig, host host.Host) (
 	} else {
 		logger.Debugf("P2P gating disabled: no private mode or blacklist; all connections allowed")
 	}
-	cg := peers.ChainConnectionGaters(wcg)
+
+	var cg connmgr.ConnectionGater
+	if wcg != nil {
+		cg = peers.ChainConnectionGaters(wcg)
+	}
 
 	if host == nil {
 		ip, portStr, err := net.SplitHostPort(cfg.KwilCfg.P2P.ListenAddress)
@@ -94,7 +99,7 @@ func NewP2PService(ctx context.Context, cfg *P2PServiceConfig, host host.Host) (
 			port:            port,
 			privKey:         cfg.PrivKey,
 			chainID:         cfg.ChainID,
-			connGater:       cg,
+			connGater:       &cg, // Pass pointer to check for nil
 			logger:          logger,
 			externalAddress: cfg.KwilCfg.P2P.ExternalAddress,
 		}

--- a/node/peers/gate.go
+++ b/node/peers/gate.go
@@ -502,11 +502,17 @@ func ChainConnectionGaters(gaters ...connmgr.ConnectionGater) connmgr.Connection
 		if g == nil {
 			continue
 		}
-		// Check for typed-nil (non-nil interface with nil underlying value)
-		if reflect.ValueOf(g).IsNil() {
-			continue
+		v := reflect.ValueOf(g)
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Slice, reflect.Func, reflect.Map, reflect.Chan:
+			if v.IsNil() {
+				continue
+			}
 		}
 		filtered = append(filtered, g)
+	}
+	if len(filtered) == 0 {
+		return nil
 	}
 	return &chainedConnectionGater{gaters: filtered}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- able to bridge to another recipient instead of caller
- fix situation where disabled blacklist causes panic on the node startup

## Related Issue
<!--- If this pull requests links to an issue, please link to it here: -->

- fix #1611 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ERC-20 bridge accepts a recipient address so bridged tokens can be delivered directly to another account; recipient selection and balance resolution improved.

* **Bug Fixes**
  * Safer P2P connection gating to avoid startup/runtime errors when gate configuration is absent.
  * Filtering out invalid/typed-nil gate entries to reduce unexpected connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->