### PR TITLE
chore: improve snapshotter & fix protocol

### DIFF
--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -745,8 +745,7 @@ var (
 )
 
 func (bp *BlockProcessor) snapshotDB(ctx context.Context, height int64) error {
-	snapshotsDue := bp.snapshotter.Enabled() &&
-		(bp.snapshotter.IsSnapshotDue(uint64(height)) || len(bp.snapshotter.ListSnapshots()) == 0)
+	snapshotsDue := bp.snapshotter.Enabled() && bp.snapshotter.IsSnapshotDue(uint64(height))
 	// snapshotsDue = snapshotsDue && height > max(1, a.cfg.InitialHeight)
 
 	if snapshotsDue {

--- a/node/snapshotter/handler.go
+++ b/node/snapshotter/handler.go
@@ -26,7 +26,7 @@ const (
 	snapshotGetTimeout      = 45 * time.Second
 
 	ProtocolIDSnapshotCatalog protocol.ID = "/kwil/snapcat/1.0.0"
-	ProtocolIDSnapshotChunk   protocol.ID = "/kwil/snapchunk/1.0.0"
+	ProtocolIDSnapshotChunk   protocol.ID = "/kwil/snapchunk/1.1.0"
 	ProtocolIDSnapshotRange   protocol.ID = "/kwil/snaprange/1.0.0"
 	ProtocolIDSnapshotMeta    protocol.ID = "/kwil/snapmeta/1.0.0"
 
@@ -63,14 +63,8 @@ func (s *SnapshotStore) snapshotCatalogRequestHandler(stream network.Stream) {
 	stream.SetReadDeadline(time.Now().Add(time.Second))
 
 	req := make([]byte, len(DiscoverSnapshotsMsg))
-	n, err := stream.Read(req)
-	if err != nil {
+	if _, err := io.ReadFull(stream, req); err != nil {
 		s.log.Warn("failed to read discover snapshots request", "error", err)
-		return
-	}
-
-	if n == 0 {
-		// no request, hung up
 		return
 	}
 

--- a/node/snapshotter/protocol_test.go
+++ b/node/snapshotter/protocol_test.go
@@ -1,0 +1,62 @@
+package snapshotter
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/trufnetwork/kwil-db/node/types"
+)
+
+func TestSnapshotChunkReqBinaryRoundTrip(t *testing.T) {
+	original := SnapshotChunkReq{
+		Height: 1234,
+		Format: 42,
+		Index:  3,
+		Hash:   types.Hash{1, 2, 3, 4},
+	}
+
+	// marshal/unmarshal
+	bts, err := original.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary failed: %v", err)
+	}
+
+	var decoded SnapshotChunkReq
+	if err := decoded.UnmarshalBinary(bts); err != nil {
+		t.Fatalf("UnmarshalBinary failed: %v", err)
+	}
+
+	if decoded.Height != original.Height || decoded.Format != original.Format || decoded.Index != original.Index || decoded.Hash != original.Hash {
+		t.Fatalf("decoded struct mismatch: %+v vs %+v", decoded, original)
+	}
+
+	// reader/writer interface
+	buf := &bytes.Buffer{}
+	if _, err := original.WriteTo(buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	var readBack SnapshotChunkReq
+	if _, err := readBack.ReadFrom(buf); err != nil {
+		t.Fatalf("ReadFrom failed: %v", err)
+	}
+
+	if readBack.Height != original.Height || readBack.Format != original.Format || readBack.Index != original.Index || readBack.Hash != original.Hash {
+		t.Fatalf("ReadFrom mismatch: %+v vs %+v", readBack, original)
+	}
+
+	// ensure size is exact
+	expectedLen := 8 + 4 + 4 + types.HashLen
+	if len(bts) != expectedLen {
+		t.Fatalf("binary length mismatch: got %d want %d", len(bts), expectedLen)
+	}
+
+	// confirm byte layout (Height|Format|Index)
+	if binary.LittleEndian.Uint32(bts[8:12]) != original.Format {
+		t.Fatalf("format not encoded correctly")
+	}
+	if binary.LittleEndian.Uint32(bts[12:16]) != original.Index {
+		t.Fatalf("index not encoded correctly")
+	}
+}

--- a/node/snapshotter/snapshotter.go
+++ b/node/snapshotter/snapshotter.go
@@ -4,18 +4,22 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"container/heap"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/trufnetwork/kwil-db/config"
 	"github.com/trufnetwork/kwil-db/core/log"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -23,26 +27,22 @@ const (
 
 	DefaultSnapshotFormat = 0
 
-	stage1output = "stage1output.sql"
-	stage2output = "stage2output.sql"
-	stage3output = "stage3output.sql.gz"
+	defaultCopySorterBuffer = 256 << 20
+	maxOpenRunFiles         = 64
 
 	CreateSchema   = "CREATE SCHEMA"
 	CreateTable    = "CREATE TABLE"
 	CreateFunction = "CREATE FUNCTION"
 )
 
-// This file deals with creating a snapshot instance at a given snapshotID
+// This file deals with creating a snapshot instance at a given snapshotID.
 // The whole process occurs in multiple stages:
-// STAGE1: Dumping the database state using pg_dump and writing it to a file
-// STAGE2: Sanitizing the dump file to make it deterministic
+// STAGE1: Streaming pg_dump output to obtain the database state at the snapshot boundary
+// STAGE2: Sanitizing the dump stream to make it deterministic
 //   - Removing white spaces, comments and SET and SELECT statements
 //   - Sorting the COPY blocks of data based on the hash of the row-data
-//
-// STAGE3: Compressing the sanitized dump file
-// STAGE4: Splitting the compressed dump file into chunks of fixed size (16MB)
-// TODO: STAGE2 could be optimized by sorting based on the first column,
-// but it might not work if the first column is not unique.
+// STAGE3: Compressing the sanitized stream with deterministic gzip headers
+// STAGE4: Splitting the compressed stream into chunks of fixed size (16MB)
 
 type NamespaceManager interface {
 	ListPostgresSchemasToDump() []string
@@ -55,6 +55,27 @@ type Snapshotter struct {
 	log          log.Logger
 }
 
+type contextReader struct {
+	ctx    context.Context
+	Reader io.Reader
+}
+
+// contextReader aborts ongoing reads as soon as the context is cancelled. It
+// lets downstream errors propagate upstream immediately instead of waiting for
+// explicit cancellation checks between copy operations.
+func (cr *contextReader) Read(p []byte) (int, error) {
+	if err := cr.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := cr.Reader.Read(p)
+	if err == nil {
+		if errCtx := cr.ctx.Err(); errCtx != nil {
+			return 0, errCtx
+		}
+	}
+	return n, err
+}
+
 func NewSnapshotter(cfg *config.DBConfig, dir string, namespaceMgr NamespaceManager, logger log.Logger) *Snapshotter {
 	return &Snapshotter{
 		dbConfig:     cfg,
@@ -64,78 +85,104 @@ func NewSnapshotter(cfg *config.DBConfig, dir string, namespaceMgr NamespaceMana
 	}
 }
 
-// CreateSnapshot creates a snapshot at the given height and snapshotID
+// CreateSnapshot orchestrates pg_dump, sanitisation, compression, and chunking
+// through a streaming pipeline. The pipeline exists specifically to avoid the
+// huge I/O spikes caused by materialising intermediate stage files in older
+// versions. By wiring the stages with pipes we cap disk usage to the final
+// chunk artefacts and surface errors as soon as a downstream stage fails.
 func (s *Snapshotter) CreateSnapshot(ctx context.Context, height uint64, snapshotID string, schemas, excludeTables []string, excludeTableData []string) (*Snapshot, error) {
 	// create snapshot directory
 	snapshotDir := snapshotHeightDir(s.snapshotDir, height)
+	formatDir := snapshotFormatDir(s.snapshotDir, height, DefaultSnapshotFormat)
 	chunkDir := snapshotChunkDir(s.snapshotDir, height, DefaultSnapshotFormat)
 	err := os.MkdirAll(chunkDir, 0755)
 	if err != nil {
 		return nil, err
 	}
 
-	// Stage1: Dump the database at the given height and snapshot ID
-	err = s.dbSnapshot(ctx, height, DefaultSnapshotFormat, snapshotID, schemas, excludeTables, excludeTableData)
+	// Stage1: Stream the database snapshot via pg_dump
+	dumpReader, waitDump, err := s.dbSnapshotStream(ctx, height, DefaultSnapshotFormat, snapshotID, schemas, excludeTables, excludeTableData)
 	if err != nil {
 		os.RemoveAll(snapshotDir)
 		return nil, err
 	}
 
-	// Stage2: Sanitize the dump
-	hash, err := s.sanitizeDump(height, DefaultSnapshotFormat)
-	if err != nil {
+	sanitizedReader, sanitizedWriter := io.Pipe()
+	compressedReader, compressedWriter := io.Pipe()
+	hashCh := make(chan []byte, 1)
+
+	var snapshot *Snapshot
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	group.Go(func() error {
+		defer sanitizedWriter.Close()
+		defer close(hashCh)
+
+		hash, err := s.sanitizeDumpStream(groupCtx, height, DefaultSnapshotFormat, formatDir, dumpReader, sanitizedWriter)
+		dumpReader.Close()
+		if err != nil {
+			sanitizedWriter.CloseWithError(err)
+			_ = waitDump()
+			return err
+		}
+
+		if err := waitDump(); err != nil {
+			sanitizedWriter.CloseWithError(err)
+			return err
+		}
+
+		hashCh <- hash
+		return nil
+	})
+
+	group.Go(func() error {
+		defer compressedWriter.Close()
+		if err := compressStream(groupCtx, sanitizedReader, compressedWriter); err != nil {
+			compressedWriter.CloseWithError(err)
+			return err
+		}
+		return nil
+	})
+
+	group.Go(func() error {
+		var err error
+		snapshot, err = s.splitStreamIntoChunks(groupCtx, height, DefaultSnapshotFormat, compressedReader, hashCh)
+		return err
+	})
+
+	if err := group.Wait(); err != nil {
+		sanitizedReader.CloseWithError(err)
+		compressedReader.CloseWithError(err)
 		os.RemoveAll(snapshotDir)
 		return nil, err
 	}
 
-	// Stage3: Compress the dump
-	err = s.compressDump(height, DefaultSnapshotFormat)
-	if err != nil {
-		os.RemoveAll(snapshotDir)
-		return nil, err
-	}
-
-	// Stage4: Split the dump into chunks
-	snapshot, err := s.splitDumpIntoChunks(height, DefaultSnapshotFormat, hash)
-	if err != nil {
-		os.RemoveAll(snapshotDir)
-		return nil, err
-	}
+	compressedReader.Close()
+	sanitizedReader.Close()
 
 	return snapshot, nil
 }
 
-// dbSnapshot is the STAGE1 of the snapshot creation process
-// It uses pg_dump to dump the database state at the given height and snapshotID
-// The pg dump is stored as "/stage1output.sql" in the snapshot directory
-// This is a temporary file and will be removed after the snapshot is created.
-// The function takes the following parameters to specify what to include in the snapshot:
-// schemas: List of schemas to include in the snapshot
-// excludeTables: List of tables to exclude from the snapshot
-// excludeTableData: List of tables for which definitions should be included but not the data
-func (s *Snapshotter) dbSnapshot(ctx context.Context, height uint64, format uint32, snapshotID string, internalSchemas, excludeTables []string, excludeTableData []string) error {
-	snapshotDir := snapshotFormatDir(s.snapshotDir, height, format)
-	dumpFile := filepath.Join(snapshotDir, stage1output)
-
+// dbSnapshotStream runs pg_dump and returns a reader for its stdout along with a function
+// that must be invoked to wait for the command to finish.
+// dbSnapshotStream launches pg_dump configured for deterministic output. It
+// returns a reader for pg_dump's stdout plus a wait function so callers can
+// observe pg_dump failures. The flag set mirrors the legacy implementation
+// (notably --no-unlogged-table-data) so streamed snapshots stay byte-compatible
+// with older ones.
+func (s *Snapshotter) dbSnapshotStream(ctx context.Context, height uint64, format uint32, snapshotID string, internalSchemas, excludeTables []string, excludeTableData []string) (io.ReadCloser, func() error, error) {
 	args := []string{
-		// File format options
-		"--file", dumpFile,
 		"--format", "plain",
-		// Snapshot ID ensures a consistent snapshot taken at the given block boundary across all nodes
 		"--dbname", s.dbConfig.DBName,
-		// Connection options
 		"-U", s.dbConfig.User,
 		"-h", s.dbConfig.Host,
 		"-p", s.dbConfig.Port,
 		"--no-password",
-		// Snapshot options
 		"--snapshot", snapshotID,
-		// other sql dump specific options
 		"--no-unlogged-table-data",
 		"--no-comments",
 		"--create",
 		"--no-publications",
-		"--no-unlogged-table-data",
 		"--no-tablespaces",
 		"--no-table-access-method",
 		"--no-security-labels",
@@ -166,6 +213,13 @@ func (s *Snapshotter) dbSnapshot(ctx context.Context, height uint64, format uint
 	}
 
 	pgDumpCmd := exec.CommandContext(ctx, "pg_dump", args...)
+	stderrBuf := &bytes.Buffer{}
+	pgDumpCmd.Stderr = stderrBuf
+
+	stdout, err := pgDumpCmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get pg_dump stdout: %w", err)
+	}
 
 	if s.dbConfig.Pass != "" {
 		pgDumpCmd.Env = append(pgDumpCmd.Env, "PGPASSWORD="+s.dbConfig.Pass)
@@ -173,304 +227,173 @@ func (s *Snapshotter) dbSnapshot(ctx context.Context, height uint64, format uint
 
 	s.log.Info("Executing pg_dump", "cmd", pgDumpCmd.String())
 
-	output, err := pgDumpCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to execute pg_dump: %w, output: %s", err, string(output))
+	if err := pgDumpCmd.Start(); err != nil {
+		stdout.Close()
+		return nil, nil, fmt.Errorf("failed to start pg_dump: %w, stderr: %s", err, stderrBuf.String())
 	}
 
-	s.log.Info("pg_dump successful", "height", height)
+	waitFn := func() error {
+		if err := pgDumpCmd.Wait(); err != nil {
+			return fmt.Errorf("failed to execute pg_dump: %w, stderr: %s", err, stderrBuf.String())
+		}
+		s.log.Info("pg_dump successful", "height", height)
+		return nil
+	}
 
-	return nil
+	return stdout, waitFn, nil
 }
 
-type hashedLine struct {
-	Hash   [32]byte // sha256 hash of the line
-	offset int64
-}
-
-// sanitizeDump is the STAGE2 of the snapshot creation process
-// This stage sanitizes the dump file to make it deterministic across all the nodes
-// It removes white spaces, comments, SET and SELECT statements
-// It sorts the COPY blocks of data based on the hash of the row-data
-// The sanitized dump is stored as "/stage2output.sql" in the snapshot directory
-// This is a temporary file and will be removed after the snapshot is created
-func (s *Snapshotter) sanitizeDump(height uint64, format uint32) ([]byte, error) {
-	// check if the stage1output file exists
-	snapshotDir := snapshotFormatDir(s.snapshotDir, height, format)
-	dumpFile := filepath.Join(snapshotDir, stage1output)
-	dumpInst1, err := os.Open(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open dump file: %w", err)
-	}
-	defer dumpInst1.Close()
-
-	dumpInst2, err := os.Open(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open dump file: %w", err)
-	}
-	defer dumpInst2.Close()
-
-	// sanitized dump file
-	sanitizedDumpFile := filepath.Join(snapshotDir, stage2output)
-	outputFile, err := os.Create(sanitizedDumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sanitized dump file: %w", err)
-	}
-	defer outputFile.Close()
-
-	reader := bufio.NewReader(dumpInst1)
+// sanitizeDumpStream normalises the pg_dump stream and sorts COPY rows in a
+// deterministic order. The heavy lifting lives in copyBlockSorter which spills
+// large COPY blocks to disk and merges them sequentially so we never re-seek
+// the original dump. That choice removes the random-I/O hotspot that previously
+// made sanitisation drag on for hours.
+func (s *Snapshotter) sanitizeDumpStream(ctx context.Context, height uint64, format uint32, tempDir string, r io.Reader, w io.Writer) ([]byte, error) {
+	reader := bufio.NewReader(r)
+	rowHasher := sha256.New()
+	bufWriter := bufio.NewWriter(io.MultiWriter(w, rowHasher))
 
 	var inCopyBlock, schemaStarted bool
-	var lineHashes []hashedLine
-	var offset int64
-	hasher := sha256.New()
+	sorter := newCopyBlockSorter(tempDir, defaultCopySorterBuffer)
+	defer sorter.Reset()
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
-			return nil, fmt.Errorf("failed to read line {%s} from pg dump file: %w", line, err)
+			return nil, fmt.Errorf("failed to read line {%s} from pg dump stream: %w", line, err)
 		}
 
-		numBytes := int64(len(line)) //  newline character is included in the line
 		trimLine := strings.TrimSpace(line)
 
 		if inCopyBlock {
-			/*
-				COPY schema.table (id, name) FROM stdin;
-				2 entry2
-				1 entry1
-				3 entry3
-				\.
-			*/
-			if trimLine == `\.` { // end of COPY block
+			if trimLine == `\.` {
 				inCopyBlock = false
 
-				// Inline sort the lineHashes array based on the row hash
-				slices.SortFunc(lineHashes, func(a, b hashedLine) int {
-					return bytes.Compare(a.Hash[:], b.Hash[:])
-				})
-
-				/*
-					TODO: Consider optimizing the sorting process:
-					- #len(lineHashes) number of fseeks per copy block -> not good, saves memory but huge IO overhead
-					- Preferably, sort based on the first column or a unique column for data locality
-				*/
-
-				// Write the sorted data to the output file based on the offset
-				for _, hashedLine := range lineHashes {
-					// Seek to the offset of the line in the input file
-					_, err := dumpInst2.Seek(hashedLine.offset, io.SeekStart)
-					if err != nil {
-						return nil, fmt.Errorf("failed to seek to offset: %w", err)
-					}
-
-					lineBytes, err := bufio.NewReader(dumpInst2).ReadBytes('\n')
-					if err != nil {
-						return nil, fmt.Errorf("failed to read line from input file: %w", err)
-					}
-
-					_, err = outputFile.Write(lineBytes)
-					if err != nil {
-						return nil, fmt.Errorf("failed to write to sanitized dump file: %w", err)
-					}
+				if err := sorter.Flush(bufWriter); err != nil {
+					return nil, err
 				}
 
-				// Write the end of COPY block to the output file
-				_, err = outputFile.WriteString(line) // \n character is included in the line
-				if err != nil {
-					return nil, fmt.Errorf("failed to write to sanitized dump file: %w", err)
+				if _, err = bufWriter.WriteString(line); err != nil {
+					return nil, fmt.Errorf("failed to write end of COPY block: %w", err)
 				}
-
-				// Clear the lineHashes array
-				lineHashes = make([]hashedLine, 0)
-				offset += numBytes
 			} else {
-				// If we are in a COPY block, we need to sort the data based on the row hash
-				hasher.Reset()
-				hasher.Write([]byte(line))
-				var hash [32]byte
-				copy(hash[:], hasher.Sum(nil))
-				lineHashes = append(lineHashes, hashedLine{Hash: hash, offset: offset})
-				offset += numBytes
+				if err := sorter.AddLine([]byte(line)); err != nil {
+					return nil, err
+				}
 			}
 		} else {
-			offset += numBytes // +1 for newline character
 			if line == "" || trimLine == "" {
-				// skip empty lines
 				continue
 			} else if strings.HasPrefix(trimLine, "--") {
-				// skip comments
 				continue
 			} else if !schemaStarted && (strings.HasPrefix(trimLine, CreateSchema) ||
 				strings.HasPrefix(trimLine, CreateTable) || strings.HasPrefix(trimLine, CreateFunction)) {
 				schemaStarted = true
-
-				// write the line to the output file
-				_, err := outputFile.WriteString(line) // \n character is included in the line
-				if err != nil {
-					return nil, fmt.Errorf("failed to write to sanitized dump file: %w", err)
+				if _, err := bufWriter.WriteString(line); err != nil {
+					return nil, fmt.Errorf("failed to write schema statement: %w", err)
 				}
 			} else if !schemaStarted && (strings.HasPrefix(trimLine, "SET") || strings.HasPrefix(trimLine, "SELECT") ||
 				strings.HasPrefix(trimLine, `\connect`) || strings.HasPrefix(trimLine, "CREATE DATABASE")) {
-				// skip any SET, SELECT, CREATE DATABASE and connect statements that appear before the schema definition
-				// These are postgres specific commands that should not be included in the snapshot
 				continue
 			} else {
-				// Example: COPY kwild_voting.voters (id, name, power) FROM stdin;
 				if strings.HasPrefix(trimLine, "COPY") && strings.Contains(trimLine, "FROM stdin;") {
-					inCopyBlock = true // start of COPY block
+					inCopyBlock = true
 				}
-				// write the line to the output file
-				_, err := outputFile.WriteString(line)
-				if err != nil {
-					return nil, fmt.Errorf("failed to write to sanitized dump file: %w", err)
+				if _, err := bufWriter.WriteString(line); err != nil {
+					return nil, fmt.Errorf("failed to write sanitized line: %w", err)
 				}
 			}
 		}
 	}
 
-	outputFile.Sync()
-
-	// remove the dump file
-	err = os.Remove(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove dump file: %w", err)
+	if err := bufWriter.Flush(); err != nil {
+		return nil, fmt.Errorf("failed to flush sanitized dump stream: %w", err)
 	}
 
-	hash, err := hashFile(sanitizedDumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to hash the sanitized dump file: %w", err)
-	}
-
-	s.log.Info("Sanitized dump file", "height", height, "snapshot-hash", fmt.Sprintf("%x", hash))
+	hash := rowHasher.Sum(nil)
+	s.log.Info("Sanitized dump stream", "height", height, "snapshot-hash", fmt.Sprintf("%x", hash))
 
 	return hash, nil
 }
 
-// CompressDump is the STAGE3 of the snapshot creation process
-// This method compresses the sanitized dump file using gzip compression
-// Should we do inline compression? or using exec.Command?
-func (s *Snapshotter) compressDump(height uint64, format uint32) error {
-	// Check if the dump file exists
-	snapshotDir := snapshotFormatDir(s.snapshotDir, height, format)
-	dumpFile := filepath.Join(snapshotDir, stage2output)
-	inputFile, err := os.Open(dumpFile)
-	if err != nil {
-		return fmt.Errorf("failed to open dump file: %w", err)
-	}
-	defer inputFile.Close()
+// compressStream wraps gzip with deterministic headers. Controlling the header
+// values prevents accidental hash mismatches when two nodes compress identical
+// input at different times.
+func compressStream(ctx context.Context, r io.Reader, w io.Writer) error {
+	gzipWriter := gzip.NewWriter(w)
+	gzipWriter.Header.ModTime = time.Unix(0, 0)
+	gzipWriter.Header.Name = ""
+	gzipWriter.Header.OS = 255
 
-	// dump file stats
-	stats, err := os.Stat(dumpFile)
-	if err != nil {
-		return fmt.Errorf("failed to get file stats: %w", err)
+	if _, err := io.Copy(gzipWriter, &contextReader{ctx: ctx, Reader: r}); err != nil {
+		gzipWriter.Close()
+		return err
 	}
 
-	compressedFile := filepath.Join(snapshotDir, stage3output)
-	outputFile, err := os.Create(compressedFile)
-	if err != nil {
-		return fmt.Errorf("failed to create compressed dump file: %w", err)
-	}
-	defer outputFile.Close()
-
-	// gzip writer
-	// Do we need faster compression at the expense of larger file size?
-	// [gzip.BestSpeed or gzip.HuffmanOnly]
-	// or slower compression for smaller file size? [gzip.BestCompression]
-	// or a balance between the two? [gzip.DefaultCompression]
-	gzipWriter := gzip.NewWriter(outputFile)
-	defer gzipWriter.Close()
-
-	_, err = io.Copy(gzipWriter, inputFile)
-	if err != nil {
-		return fmt.Errorf("failed to copy data to compressed dump file: %w", err)
-	}
-
-	if err := gzipWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close gzip writer: %w", err)
-	}
-
-	compressedStats, err := os.Stat(compressedFile)
-	if err != nil {
-		return fmt.Errorf("failed to get file stats: %w", err)
-	}
-
-	// Remove the sanitized dump file
-	err = os.Remove(dumpFile)
-	if err != nil {
-		return fmt.Errorf("failed to remove dump file: %w", err)
-	}
-
-	s.log.Info("Dump file compressed", "height", height, "Uncompressed dump size", uint64(stats.Size()), "Compressed dump size", uint64(compressedStats.Size()))
-
-	return nil
+	return gzipWriter.Close()
 }
 
-// SplitDumpIntoChunks is the STAGE4 of the snapshot creation process
-// This method splits the compressed dump file into chunks of fixed size (16MB)
-// The chunks are stored in the height/format/chunks directory
-// The snapshot header is created and stored in the height/format/header.json file
-func (s *Snapshotter) splitDumpIntoChunks(height uint64, format uint32, sqlDumpHash []byte) (*Snapshot, error) {
-	// check if the dump file exists
-	snapshotDir := snapshotFormatDir(s.snapshotDir, height, format)
-	dumpFile := filepath.Join(snapshotDir, stage3output)
-	inputFile, err := os.Open(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open dump file: %w", err)
-	}
-	defer inputFile.Close()
-
-	// split the dump file into chunks
+// splitStreamIntoChunks writes the compressed stream into on-disk chunk files.
+// We hash each chunk while it is written to avoid double-reading the data and
+// to keep the snapshot header in sync with the files we just produced.
+func (s *Snapshotter) splitStreamIntoChunks(ctx context.Context, height uint64, format uint32, r io.Reader, hashCh <-chan []byte) (*Snapshot, error) {
 	var chunkIndex uint32
 	var hashes [][HashLen]byte
 	var fileSize uint64
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		chunkFileName := snapshotChunkFile(s.snapshotDir, height, format, chunkIndex)
 		chunkFile, err := os.Create(chunkFileName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create chunk file: %w", err)
 		}
-		defer chunkFile.Close()
 
-		// write the chunk to the file
-		written, err := io.CopyN(chunkFile, inputFile, chunkSize)
-		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("failed to write chunk to file: %w", err)
+		hasher := sha256.New()
+		multiWriter := io.MultiWriter(chunkFile, hasher)
+		written, copyErr := io.CopyN(multiWriter, &contextReader{ctx: ctx, Reader: r}, chunkSize)
+
+		if err := chunkFile.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close chunk file: %w", err)
 		}
-		chunkFile.Close() // chunkFile.Sync() probably
 
-		// calculate the hash of the chunk
+		if copyErr != nil {
+			if copyErr != io.EOF {
+				os.Remove(chunkFileName)
+				return nil, fmt.Errorf("failed to write chunk to file: %w", copyErr)
+			}
+			if written == 0 {
+				os.Remove(chunkFileName)
+				break
+			}
+		}
+
 		var chunkHash [HashLen]byte
-		hash, err := hashFile(chunkFileName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to hash the chunk file: %w", err)
-		}
-
-		copy(chunkHash[:], hash)
+		copy(chunkHash[:], hasher.Sum(nil))
 
 		hashes = append(hashes, chunkHash)
 		fileSize += uint64(written)
 		chunkIndex++
 
-		s.log.Info("Chunk created", "index", chunkIndex, "chunkfile", chunkFileName, "size", written)
+		indexLogged := chunkIndex - 1
+		s.log.Info("Chunk created", "index", indexLogged, "chunkfile", chunkFileName, "size", written)
 
-		if err == io.EOF || written < chunkSize {
-			break // EOF, Last chunk
+		if copyErr == io.EOF || written < chunkSize {
+			break
 		}
-
 	}
 
-	// get file size
-	fileInfo, err := os.Stat(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get file stats: %w", err)
-	}
-	if fileSize != uint64(fileInfo.Size()) {
-		return nil, fmt.Errorf("file size mismatch: %d != %d", fileSize, fileInfo.Size())
+	sqlDumpHash, ok := <-hashCh
+	if !ok {
+		return nil, fmt.Errorf("sanitized hash unavailable")
 	}
 
 	snapshot := &Snapshot{
@@ -482,20 +405,366 @@ func (s *Snapshotter) splitDumpIntoChunks(height uint64, format uint32, sqlDumpH
 		SnapshotSize: fileSize,
 	}
 	headerFile := snapshotHeaderFile(s.snapshotDir, height, format)
-	err = snapshot.SaveAs(headerFile)
-	if err != nil {
+	if err := snapshot.SaveAs(headerFile); err != nil {
 		return nil, fmt.Errorf("failed to save snapshot header: %w", err)
 	}
 
-	// remove the compressed dump file
-	err = os.Remove(dumpFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove dump file: %w", err)
-	}
-
-	s.log.Info("Chunk files created successfully", "height", height, "chunk-count", chunkIndex, "Total Snapzhot Size", fileSize)
+	s.log.Info("Chunk files created successfully", "height", height, "chunk-count", chunkIndex, "Total Snapshot Size", fileSize)
 
 	return snapshot, nil
+}
+
+type copyRow struct {
+	hash [32]byte
+	data []byte
+}
+
+type copyBlockSorter struct {
+	tempDir string
+	limit   int
+	rows    []copyRow
+	rowSize int
+	spills  []*os.File
+}
+
+func newCopyBlockSorter(tempDir string, limit int) *copyBlockSorter {
+	if limit <= 0 {
+		limit = defaultCopySorterBuffer
+	}
+	return &copyBlockSorter{
+		tempDir: tempDir,
+		limit:   limit,
+	}
+}
+
+func (s *copyBlockSorter) AddLine(line []byte) error {
+	if len(line) == 0 {
+		return nil
+	}
+	rowCopy := append([]byte(nil), line...)
+	row := copyRow{
+		hash: sha256.Sum256(rowCopy),
+		data: rowCopy,
+	}
+	s.rows = append(s.rows, row)
+	s.rowSize += len(rowCopy)
+	if s.rowSize >= s.limit {
+		return s.spill()
+	}
+	return nil
+}
+
+func (s *copyBlockSorter) Flush(w io.Writer) error {
+	defer s.Reset()
+
+	if len(s.spills) == 0 {
+		s.sortInMemory()
+		for _, row := range s.rows {
+			if _, err := w.Write(row.data); err != nil {
+				return err
+			}
+		}
+		s.rows = nil
+		s.rowSize = 0
+		return nil
+	}
+
+	if len(s.rows) > 0 {
+		if err := s.spill(); err != nil {
+			return err
+		}
+	}
+
+	if err := s.reduceRuns(maxOpenRunFiles); err != nil {
+		return err
+	}
+
+	readers := make([]*runReader, 0, len(s.spills))
+	for _, f := range s.spills {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		readers = append(readers, newRunReader(f))
+	}
+
+	h := mergeHeap{}
+	heap.Init(&h)
+	for _, r := range readers {
+		row, err := r.next()
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			return err
+		}
+		heap.Push(&h, mergeItem{row: row, reader: r})
+	}
+
+	for h.Len() > 0 {
+		item := heap.Pop(&h).(mergeItem)
+		if _, err := w.Write(item.row.data); err != nil {
+			return err
+		}
+		next, err := item.reader.next()
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			return err
+		}
+		heap.Push(&h, mergeItem{row: next, reader: item.reader})
+	}
+
+	return nil
+}
+
+func (s *copyBlockSorter) Reset() {
+	for _, f := range s.spills {
+		name := f.Name()
+		f.Close()
+		os.Remove(name)
+	}
+	s.spills = nil
+	s.rows = nil
+	s.rowSize = 0
+}
+
+func (s *copyBlockSorter) reduceRuns(maxOpen int) error {
+	if maxOpen <= 0 {
+		return errors.New("maxOpen must be positive")
+	}
+
+	for len(s.spills) > maxOpen {
+		batch := append([]*os.File(nil), s.spills[:maxOpen]...)
+		merged, err := s.mergeRunBatch(batch)
+		if err != nil {
+			return err
+		}
+
+		for _, f := range batch {
+			f.Close()
+			os.Remove(f.Name())
+		}
+
+		rest := append([]*os.File(nil), s.spills[maxOpen:]...)
+		s.spills = append([]*os.File{merged}, rest...)
+	}
+
+	return nil
+}
+
+func (s *copyBlockSorter) mergeRunBatch(batch []*os.File) (*os.File, error) {
+	file, err := os.CreateTemp(s.tempDir, "copy-merge-*.tmp")
+	if err != nil {
+		return nil, err
+	}
+
+	writer := bufio.NewWriter(file)
+	readers := make([]*runReader, 0, len(batch))
+
+	for _, f := range batch {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+		readers = append(readers, newRunReader(f))
+	}
+
+	h := mergeHeap{}
+	heap.Init(&h)
+	for _, r := range readers {
+		row, err := r.next()
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+		heap.Push(&h, mergeItem{row: row, reader: r})
+	}
+
+	for h.Len() > 0 {
+		item := heap.Pop(&h).(mergeItem)
+		if len(item.row.data) > int(^uint32(0)) {
+			file.Close()
+			os.Remove(file.Name())
+			return nil, fmt.Errorf("copy row exceeds maximum size: %d", len(item.row.data))
+		}
+		if err := binary.Write(writer, binary.LittleEndian, uint32(len(item.row.data))); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+		if _, err := writer.Write(item.row.hash[:]); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+		if _, err := writer.Write(item.row.data); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+
+		next, err := item.reader.next()
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			file.Close()
+			os.Remove(file.Name())
+			return nil, err
+		}
+		heap.Push(&h, mergeItem{row: next, reader: item.reader})
+	}
+
+	if err := writer.Flush(); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return nil, err
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (s *copyBlockSorter) spill() error {
+	if len(s.rows) == 0 {
+		return nil
+	}
+
+	s.sortInMemory()
+	file, err := os.CreateTemp(s.tempDir, "copy-run-*.tmp")
+	if err != nil {
+		return err
+	}
+
+	bufWriter := bufio.NewWriter(file)
+	for _, row := range s.rows {
+		if len(row.data) > int(^uint32(0)) {
+			file.Close()
+			os.Remove(file.Name())
+			return fmt.Errorf("copy row exceeds maximum size: %d", len(row.data))
+		}
+		if err := binary.Write(bufWriter, binary.LittleEndian, uint32(len(row.data))); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return err
+		}
+		if _, err := bufWriter.Write(row.hash[:]); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return err
+		}
+		if _, err := bufWriter.Write(row.data); err != nil {
+			file.Close()
+			os.Remove(file.Name())
+			return err
+		}
+	}
+
+	if err := bufWriter.Flush(); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return err
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return err
+	}
+
+	s.spills = append(s.spills, file)
+	s.rows = nil
+	s.rowSize = 0
+	return nil
+}
+
+func (s *copyBlockSorter) sortInMemory() {
+	if len(s.rows) <= 1 {
+		return
+	}
+	// stable sort to preserve input order when hashes and rows match
+	slices.SortStableFunc(s.rows, func(a, b copyRow) int {
+		if cmp := bytes.Compare(a.hash[:], b.hash[:]); cmp != 0 {
+			return cmp
+		}
+		return bytes.Compare(a.data, b.data)
+	})
+}
+
+type runReader struct {
+	file   *os.File
+	reader *bufio.Reader
+}
+
+func newRunReader(f *os.File) *runReader {
+	return &runReader{
+		file:   f,
+		reader: bufio.NewReader(f),
+	}
+}
+
+func (r *runReader) next() (copyRow, error) {
+	var length uint32
+	if err := binary.Read(r.reader, binary.LittleEndian, &length); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return copyRow{}, io.EOF
+		}
+		return copyRow{}, err
+	}
+
+	var hash [32]byte
+	if _, err := io.ReadFull(r.reader, hash[:]); err != nil {
+		return copyRow{}, err
+	}
+
+	data := make([]byte, int(length))
+	if _, err := io.ReadFull(r.reader, data); err != nil {
+		return copyRow{}, err
+	}
+
+	return copyRow{hash: hash, data: data}, nil
+}
+
+type mergeItem struct {
+	row    copyRow
+	reader *runReader
+}
+
+type mergeHeap []mergeItem
+
+func (h mergeHeap) Len() int { return len(h) }
+
+func (h mergeHeap) Less(i, j int) bool {
+	if cmp := bytes.Compare(h[i].row.hash[:], h[j].row.hash[:]); cmp != 0 {
+		return cmp < 0
+	}
+	return bytes.Compare(h[i].row.data, h[j].row.data) < 0
+}
+
+func (h mergeHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *mergeHeap) Push(x any) {
+	item := x.(mergeItem)
+	*h = append(*h, item)
+}
+
+func (h *mergeHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
 }
 
 func hashFile(path string) ([]byte, error) {

--- a/node/snapshotter/snapshotter_test.go
+++ b/node/snapshotter/snapshotter_test.go
@@ -2,13 +2,20 @@ package snapshotter
 
 import (
 	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/kwil-db/config"
 	"github.com/trufnetwork/kwil-db/core/log"
-	"github.com/trufnetwork/kwil-db/core/utils"
 )
 
 const (
@@ -37,30 +44,23 @@ func TestSanitizeLogicalDump(t *testing.T) {
 	err := os.MkdirAll(formatDir, 0755)
 	require.NoError(t, err)
 
-	// copy the logical dump file1
-	stage1File := filepath.Join(formatDir, stage1output)
-	err = utils.CopyFile(dump1File, stage1File)
+	data1, err := os.ReadFile(dump1File)
+	require.NoError(t, err)
+	data2, err := os.ReadFile(dump2File)
 	require.NoError(t, err)
 
-	hash1, err := snapshotter.sanitizeDump(height, 0)
+	var buf1 bytes.Buffer
+	hash1, err := snapshotter.sanitizeDumpStream(context.Background(), height, 0, formatDir, bytes.NewReader(data1), &buf1)
 	require.NoError(t, err)
 
-	// Sanitize the second dump file
-	err = utils.CopyFile(dump2File, stage1File)
+	var buf2 bytes.Buffer
+	hash2, err := snapshotter.sanitizeDumpStream(context.Background(), height, 0, formatDir, bytes.NewReader(data2), &buf2)
 	require.NoError(t, err)
 
-	hash2, err := snapshotter.sanitizeDump(height, 0)
-	require.NoError(t, err)
-
-	// Ensure that both the sanitized dumps are same
 	require.Equal(t, hash1, hash2)
+	require.Equal(t, buf1.Bytes(), buf2.Bytes())
 
-	// Check the sanitized file
-	stage2File := filepath.Join(formatDir, stage2output)
-	sanitizedFile, err := os.Open(stage2File)
-	require.NoError(t, err)
-
-	scanner := bufio.NewScanner(sanitizedFile)
+	scanner := bufio.NewScanner(bytes.NewReader(buf1.Bytes()))
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Ensure that the line does not begin with SET, SELECT or white spaces
@@ -69,4 +69,136 @@ func TestSanitizeLogicalDump(t *testing.T) {
 
 	err = scanner.Err()
 	require.NoError(t, err)
+}
+
+func TestCompressStreamDeterministic(t *testing.T) {
+	data := []byte("deterministic data\n")
+
+	var first bytes.Buffer
+	require.NoError(t, compressStream(context.Background(), bytes.NewReader(data), &first))
+
+	var second bytes.Buffer
+	require.NoError(t, compressStream(context.Background(), bytes.NewReader(data), &second))
+
+	require.Equal(t, first.Bytes(), second.Bytes())
+}
+
+func TestSplitDumpIntoChunksExactMultiple(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.DiscardLogger
+	snapshotter := NewSnapshotter(nil, dir, &MockNamespaceManager{}, logger)
+
+	height := uint64(11)
+	require.NoError(t, os.MkdirAll(snapshotChunkDir(dir, height, 0), 0o755))
+
+	data := bytes.Repeat([]byte{0x42}, int(chunkSize))
+	channel := make(chan []byte, 1)
+	channel <- []byte{1, 2, 3}
+	close(channel)
+
+	snapshot, err := snapshotter.splitStreamIntoChunks(context.Background(), height, 0, bytes.NewReader(data), channel)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), snapshot.ChunkCount)
+
+	entries, err := os.ReadDir(snapshotChunkDir(dir, height, 0))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	chunkPath := snapshotChunkFile(dir, height, 0, 0)
+	fi, err := os.Stat(chunkPath)
+	require.NoError(t, err)
+	require.EqualValues(t, len(data), fi.Size())
+}
+
+func TestCopyBlockSorterSpillAndMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+	sorter := newCopyBlockSorter(tmpDir, 32)
+
+	lines := []string{
+		"row-c\n",
+		"row-a\n",
+		"row-b\n",
+		"row-d\n",
+	}
+
+	for _, line := range lines {
+		require.NoError(t, sorter.AddLine([]byte(line)))
+	}
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, sorter.Flush(buf))
+
+	expectedLines := make([]string, len(lines))
+	copy(expectedLines, lines)
+	sort.SliceStable(expectedLines, func(i, j int) bool {
+		iHash := sha256.Sum256([]byte(expectedLines[i]))
+		jHash := sha256.Sum256([]byte(expectedLines[j]))
+		if cmp := bytes.Compare(iHash[:], jHash[:]); cmp != 0 {
+			return cmp < 0
+		}
+		return expectedLines[i] < expectedLines[j]
+	})
+
+	require.Equal(t, []byte(strings.Join(expectedLines, "")), buf.Bytes())
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 0, "spill files should be cleaned up")
+}
+
+func TestCreateSnapshotStreaming(t *testing.T) {
+	cfg := &config.DBConfig{DBName: "ignored", User: "ignored", Host: "localhost", Port: "5432"}
+	dir := t.TempDir()
+	logger := log.DiscardLogger
+	snapshotter := NewSnapshotter(cfg, dir, &MockNamespaceManager{}, logger)
+
+	dumpBytes, err := os.ReadFile(filepath.Join("test_data", "dump1.sql"))
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(dir, "pg_dump")
+	script := "#!/bin/sh\ncat <<'EOF'\n" + string(dumpBytes) + "\nEOF\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	originalPath := os.Getenv("PATH")
+	newPath := dir
+	if originalPath != "" {
+		newPath = dir + string(os.PathListSeparator) + originalPath
+	}
+	t.Setenv("PATH", newPath)
+
+	height := uint64(42)
+	var expected bytes.Buffer
+	expectedHash, err := snapshotter.sanitizeDumpStream(context.Background(), height, 0, t.TempDir(), bytes.NewReader(dumpBytes), &expected)
+	require.NoError(t, err)
+
+	snapshot, err := snapshotter.CreateSnapshot(context.Background(), height, "snapshot-stream-test", nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, snapshot.SnapshotHash)
+	require.Equal(t, uint32(1), snapshot.ChunkCount)
+
+	chunkPath := snapshotChunkFile(dir, height, 0, 0)
+	chunkFile, err := os.Open(chunkPath)
+	require.NoError(t, err)
+	defer chunkFile.Close()
+
+	gzReader, err := gzip.NewReader(chunkFile)
+	require.NoError(t, err)
+	defer gzReader.Close()
+
+	chunkContent, err := io.ReadAll(gzReader)
+	require.NoError(t, err)
+	require.Equal(t, expected.Bytes(), chunkContent)
+
+	headerPath := snapshotHeaderFile(dir, height, 0)
+	headerInfo, err := os.Stat(headerPath)
+	require.NoError(t, err)
+	require.False(t, headerInfo.IsDir())
+
+	formatEntries, err := os.ReadDir(snapshotFormatDir(dir, height, 0))
+	require.NoError(t, err)
+	require.Len(t, formatEntries, 2)
+
+	chunkDirEntries, err := os.ReadDir(snapshotChunkDir(dir, height, 0))
+	require.NoError(t, err)
+	require.Len(t, chunkDirEntries, 1)
 }

--- a/node/snapshotter/store.go
+++ b/node/snapshotter/store.go
@@ -114,7 +114,19 @@ func (s *SnapshotStore) IsSnapshotDue(height uint64) bool {
 		return false
 	}
 
-	return (height % s.cfg.RecurringHeight) == 0
+	s.snapshotsMtx.RLock()
+	defer s.snapshotsMtx.RUnlock()
+
+	if len(s.snapshotHeights) == 0 {
+		return true
+	}
+
+	lastHeight := s.snapshotHeights[len(s.snapshotHeights)-1]
+	if height <= lastHeight {
+		return false
+	}
+
+	return height-lastHeight >= s.cfg.RecurringHeight
 }
 
 // List snapshots lists all the registered snapshots in the snapshot store.
@@ -321,7 +333,7 @@ func (s *SnapshotStore) loadSnapshots() error {
 		}
 
 		// Ensure that the chunk files exist
-		for i := range header.ChunkCount {
+		for i := uint32(0); i < header.ChunkCount; i++ {
 			chunkFile := snapshotChunkFile(s.cfg.SnapshotDir, heightInt, DefaultSnapshotFormat, i)
 			if _, err := os.Stat(chunkFile); err != nil { // chunk file doesn't exist
 				s.log.Warn("Invalid snapshot chunk file, ignoring the snapshot", "chunk_file", chunkFile, "err", err)

--- a/node/statesync_test.go
+++ b/node/statesync_test.go
@@ -32,7 +32,7 @@ var (
 
 	snap1 = &snapshotMetadata{
 		Height:      1,
-		Format:      1,
+		Format:      snapshotter.DefaultSnapshotFormat,
 		Chunks:      1,
 		Hash:        data[:],
 		Size:        100,
@@ -41,7 +41,7 @@ var (
 
 	snap2 = &snapshotMetadata{
 		Height:      2,
-		Format:      1,
+		Format:      snapshotter.DefaultSnapshotFormat,
 		Chunks:      1,
 		Hash:        []byte("snap2"),
 		Size:        100,
@@ -258,6 +258,9 @@ func (s *snapshotStore) LoadSnapshotChunk(height uint64, format uint32, index ui
 	snapshot, ok := s.snapshots[height]
 	if !ok {
 		return nil, errors.New("snapshot not found")
+	}
+	if format != snapshotter.DefaultSnapshotFormat {
+		return nil, errors.New("unsupported format")
 	}
 
 	if index >= snapshot.Chunks {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR introduces several enhancements to the snapshot handling process, focusing on improving type safety and streamlining functionality. Key changes include:

- Replaced hardcoded snapshot format values with `snapshotter.DefaultSnapshotFormat` for better maintainability.
- Added error handling for unsupported snapshot formats in the `LoadSnapshotChunk` method.
- Updated the `snapshotDB` function to simplify the logic for determining if snapshots are due.
- Enhanced the `SnapshotChunkReq` struct to ensure correct binary marshaling and unmarshaling, including adjustments to the byte layout.
- Introduced a new test file for `SnapshotChunkReq` to validate binary round-trip functionality and ensure data integrity.
- fix the bug in the protocol that ignored the format and included that bit of information in the hash (note, this is breaking!)

## Related Issue
<!--- If this pull requests links to an issue, please link to it here: -->

- fix #1526 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->