### PR TITLE
feat: view catch-up indicator to block context

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -97,6 +97,9 @@ func buildServer(ctx context.Context, d *coreDependencies) *server {
 	// BlockProcessor
 	bp := buildBlockProcessor(ctx, d, db, txApp, accounts, vs, snapshotStore, es, migrator, bs, mp)
 
+	// Update TxApp's service with NodeStatus from BlockProcessor
+	txApp.UpdateNodeStatus(bp.NodeStatus())
+
 	// Consensus
 	ce := buildConsensusEngine(ctx, d, db, mp, bs, bp)
 

--- a/common/common.go
+++ b/common/common.go
@@ -13,6 +13,16 @@ import (
 	"github.com/trufnetwork/kwil-db/node/types/sql"
 )
 
+// NodeStatusProvider provides runtime status information about the node.
+// Extensions can use this to query node state and adapt their behavior
+// accordingly (e.g., skip heavy operations during synchronization).
+type NodeStatusProvider interface {
+	// IsSyncing returns true if the node is currently synchronizing with
+	// the network (i.e., catching up with blocks). This includes initial
+	// sync, block sync after restart, and snapshot restoration.
+	IsSyncing() bool
+}
+
 // Service provides access to general application information to
 // extensions.
 type Service struct {
@@ -27,6 +37,10 @@ type Service struct {
 
 	// Identity is the node/validator identity (pubkey).
 	Identity []byte // maybe this actuall needs to be crypto.PubKey???
+
+	// NodeStatus provides runtime status information about the node.
+	// Extensions can query this to adapt behavior based on node state.
+	NodeStatus NodeStatusProvider
 }
 
 // NameLogger returns a new Service with the logger named.
@@ -37,6 +51,7 @@ func (s *Service) NamedLogger(name string) *Service {
 		GenesisConfig: s.GenesisConfig,
 		LocalConfig:   s.LocalConfig,
 		Identity:      s.Identity,
+		NodeStatus:    s.NodeStatus,
 	}
 }
 

--- a/common/context.go
+++ b/common/context.go
@@ -44,6 +44,11 @@ type BlockContext struct {
 	Timestamp int64
 	// Proposer gets the proposer public key of the current block.
 	Proposer crypto.PublicKey
+	// InCatchup indicates whether the node is currently catching up
+	// with the network (i.e., in block sync mode). Extensions can use
+	// this to skip heavy operations during catch-up to reduce resource
+	// contention.
+	InCatchup bool
 }
 
 // MigrationContext provides context for all migration operations.

--- a/common/context.go
+++ b/common/context.go
@@ -44,11 +44,6 @@ type BlockContext struct {
 	Timestamp int64
 	// Proposer gets the proposer public key of the current block.
 	Proposer crypto.PublicKey
-	// InCatchup indicates whether the node is currently catching up
-	// with the network (i.e., in block sync mode). Extensions can use
-	// this to skip heavy operations during catch-up to reduce resource
-	// contention.
-	InCatchup bool
 }
 
 // MigrationContext provides context for all migration operations.

--- a/node/block_processor/node_status_test.go
+++ b/node/block_processor/node_status_test.go
@@ -1,0 +1,162 @@
+package blockprocessor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufnetwork/kwil-db/common"
+	"github.com/trufnetwork/kwil-db/core/crypto"
+	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	"github.com/trufnetwork/kwil-db/core/log"
+	ktypes "github.com/trufnetwork/kwil-db/core/types"
+)
+
+// Mock implementations are in transactions_test.go
+
+// TestNodeStatusConcurrency verifies thread-safe access to nodeStatus
+func TestNodeStatusConcurrency(t *testing.T) {
+	ns := newNodeStatus()
+
+	// Verify initial state
+	assert.False(t, ns.IsSyncing(), "node should not be syncing initially")
+
+	// Concurrent writes and reads
+	var wg sync.WaitGroup
+	iterations := 100
+
+	// Writers
+	for i := range 10 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for range iterations {
+				ns.setSyncing(id%2 == 0) // Alternate true/false
+			}
+		}(i)
+	}
+
+	// Readers
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = ns.IsSyncing()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Should not panic and should have a valid state
+	syncing := ns.IsSyncing()
+	assert.IsType(t, false, syncing, "IsSyncing should return a boolean")
+}
+
+// TestNodeStatusStateTransitions verifies correct state transitions
+func TestNodeStatusStateTransitions(t *testing.T) {
+	ns := newNodeStatus()
+
+	// Initial state
+	assert.False(t, ns.IsSyncing(), "initial state should be not syncing")
+
+	// Transition to syncing
+	ns.setSyncing(true)
+	assert.True(t, ns.IsSyncing(), "should be syncing after setSyncing(true)")
+
+	// Stay in syncing
+	ns.setSyncing(true)
+	assert.True(t, ns.IsSyncing(), "should remain syncing")
+
+	// Transition to not syncing
+	ns.setSyncing(false)
+	assert.False(t, ns.IsSyncing(), "should not be syncing after setSyncing(false)")
+
+	// Stay in not syncing
+	ns.setSyncing(false)
+	assert.False(t, ns.IsSyncing(), "should remain not syncing")
+
+	// Multiple rapid transitions
+	for i := range 10 {
+		ns.setSyncing(i%2 == 0)
+		expected := i%2 == 0
+		assert.Equal(t, expected, ns.IsSyncing(), "state should match last setSyncing call")
+	}
+}
+
+// TestNodeStatusImplementsInterface verifies nodeStatus implements NodeStatusProvider
+func TestNodeStatusImplementsInterface(t *testing.T) {
+	ns := newNodeStatus()
+
+	// This will fail to compile if nodeStatus doesn't implement the interface
+	var _ interface{ IsSyncing() bool } = ns
+
+	// Verify it works as expected
+	assert.False(t, ns.IsSyncing())
+	ns.setSyncing(true)
+	assert.True(t, ns.IsSyncing())
+}
+
+// TestBlockProcessorNodeStatusIntegration verifies BlockProcessor properly manages nodeStatus
+func TestBlockProcessorNodeStatusIntegration(t *testing.T) {
+	// Create minimal BlockProcessor with nodeStatus
+	nodePrivKey, err := crypto.GeneratePrivateKey(crypto.KeyTypeSecp256k1)
+	require.NoError(t, err)
+	nodeSigner := auth.GetNodeSigner(nodePrivKey)
+
+	chainCtx := &common.ChainContext{
+		ChainID: "test",
+		NetworkParameters: &ktypes.NetworkParameters{
+			MaxBlockSize:     1024 * 1024,
+			MaxVotesPerTx:    100,
+			DisabledGasCosts: true,
+		},
+	}
+
+	bp := &BlockProcessor{
+		db:         &mockDB{},
+		txapp:      &mockTxApp{},
+		log:        log.DiscardLogger,
+		signer:     nodeSigner,
+		chainCtx:   chainCtx,
+		nodeStatus: newNodeStatus(),
+	}
+
+	// Initially not syncing
+	assert.False(t, bp.NodeStatus().IsSyncing(), "initial state should be not syncing")
+
+	// Execute block with syncing=true
+	bp.nodeStatus.setSyncing(true)
+	assert.True(t, bp.NodeStatus().IsSyncing(), "should be syncing during block sync")
+
+	// Simulate transition to normal operation
+	bp.nodeStatus.setSyncing(false)
+	assert.False(t, bp.NodeStatus().IsSyncing(), "should not be syncing after sync complete")
+}
+
+// TestBlockProcessorNodeStatusExposedViaGetter verifies NodeStatus() returns non-nil provider
+func TestBlockProcessorNodeStatusExposedViaGetter(t *testing.T) {
+	bp := &BlockProcessor{
+		nodeStatus: newNodeStatus(),
+	}
+
+	// Verify NodeStatus is accessible
+	nodeStatus := bp.NodeStatus()
+	require.NotNil(t, nodeStatus, "NodeStatus should not be nil")
+
+	// Verify it implements the interface
+	var _ common.NodeStatusProvider = nodeStatus
+
+	// Verify initial state
+	assert.False(t, nodeStatus.IsSyncing(), "initial state should be not syncing")
+
+	// Verify state can be queried and changed
+	bp.nodeStatus.setSyncing(true)
+	assert.True(t, nodeStatus.IsSyncing(), "state should reflect changes")
+
+	bp.nodeStatus.setSyncing(false)
+	assert.False(t, nodeStatus.IsSyncing(), "state should reflect changes")
+}

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -392,6 +392,7 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 		ChainContext: bp.chainCtx,
 		Proposer:     req.Proposer,
 		Hash:         req.BlockID,
+		InCatchup:    syncing,
 	}
 
 	// Begin executing transactions. The chain context may be updated during the block execution.

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -79,6 +79,13 @@ func NewTxApp(ctx context.Context, db sql.Executor, engine common.Engine, signer
 	return t, nil
 }
 
+// UpdateNodeStatus updates the service's NodeStatus provider.
+// This should be called after the BlockProcessor is created to wire up
+// the node status for extensions to use.
+func (r *TxApp) UpdateNodeStatus(nodeStatus common.NodeStatusProvider) {
+	r.service.NodeStatus = nodeStatus
+}
+
 // GenesisInit initializes the TxApp. It must be called outside of a session,
 // and before any session is started.
 // It can assign the initial validator set and initial account balances.


### PR DESCRIPTION
Extensions can now determine if the node is synchronizing with the network by checking the InCatchup field in BlockContext. This enables extensions to defer resource-intensive operations during initial sync or snapshot restoration, preventing system overload and improving node stability.

The block processor now populates this field based on the existing syncing parameter passed to ExecuteBlock, making the information available to all extensions through the block execution hooks.

This change is backward compatible - the new field defaults to false when not explicitly set, maintaining existing behavior for extensions that don't check it.

Changes:
- Added InCatchup bool field to common.BlockContext
- Block processor sets InCatchup from syncing parameter in ExecuteBlock
- Documented field usage for extension developers

Benefits:
- Reduces resource contention during node synchronization
- Prevents replication failures during snapshot restore
- Enables smarter resource management across all extensions
- No breaking changes to existing extension code

resolves: https://github.com/trufnetwork/truf-network/issues/1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposes node syncing status to extensions and services and wires that status into the transaction application during startup.

- Tests
  - Added comprehensive tests covering thread-safe node status access, state transitions, and integration with block processing.

- Chores
  - Internal plumbing to propagate node status across components while preserving existing block-processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->